### PR TITLE
プロトタイプ投稿機能および一覧表示機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,7 @@ group :development do
   gem 'rubocop', require: false
 end
 
-
+gem 'pry-rails'
 gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    coderay (1.1.3)
     concurrent-ruby (1.2.3)
     crass (1.0.6)
     date (3.3.4)
@@ -153,6 +154,11 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.6)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     psych (5.1.2)
       stringio
     public_suffix (5.0.5)
@@ -269,13 +275,14 @@ DEPENDENCIES
   bootsnap
   capybara
   debug
-  image_processing (~> 1.2)
   devise
+  image_processing (~> 1.2)
   importmap-rails
   jbuilder
   mini_magick
   mysql2 (~> 0.5)
   pg
+  pry-rails
   puma (~> 5.0)
   rails (~> 7.0.0)
   rubocop

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,6 +1,7 @@
 class PrototypesController < ApplicationController
 
   def index
+    @prototypes = Prototype.all
   end
 
   def create
@@ -18,8 +19,7 @@ class PrototypesController < ApplicationController
 
   private
   def prototype_params
-    # ユーザー管理機能と統合した際にユーザーIDをmargeするコードを追加する(コードの内容が正しいのかは確認すること)
-    params.require(:prototype).permit(:title, :catch_copy, :concept, :image) #.merge(user_id: current_user.id)
+    params.require(:prototype).permit(:title, :catch_copy, :concept, :image).merge(user_id: current_user.id)
   end
 
 end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -1,6 +1,5 @@
 class Prototype < ApplicationRecord
-  #ユーザー管理機能と統合した際に下記をコメントアウト
-  #belongs_to :user
+  belongs_to :user
   has_one_attached :image
 
   validates :title, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  has_many :prototypes
+
   validates :name, presence: true
   validates :profile, presence: true
   validates :occupation, presence: true

--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -5,6 +5,6 @@
     <p class="card__summary">
       <%= prototype.catch_copy %>
     </p>
-    <%= link_to "by プロトタイプの投稿者名", root_path, class: :card__user %>
+    <%= link_to "by #{prototype.user.name}", root_path, class: :card__user %>
   </div>
 </div>

--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -1,0 +1,10 @@
+<div class="card">
+  <%= link_to image_tag(prototype.image, class: :card__img ), root_path %>
+  <div class="card__body">
+    <%= link_to prototype.title, root_path, class: :card__title%>
+    <p class="card__summary">
+      <%= prototype.catch_copy %>
+    </p>
+    <%= link_to "by プロトタイプの投稿者名", root_path, class: :card__user %>
+  </div>
+</div>

--- a/app/views/prototypes/index.html.erb
+++ b/app/views/prototypes/index.html.erb
@@ -7,7 +7,9 @@
       <%# </div> %>
     <%# // ログインしているときは上記を表示する %>
     <div class="card__wrapper">
-      <%# 投稿機能実装後、部分テンプレートでプロトタイプ投稿一覧を表示する %>
+      <% @prototypes.each do |prototype| %>
+        <%= render partial: "prototype", locals: { prototype: prototype } %>
+      <% end %>
     </div>
   </div>
 </main>

--- a/app/views/prototypes/index.html.erb
+++ b/app/views/prototypes/index.html.erb
@@ -7,9 +7,7 @@
       <%# </div> %>
     <%# // ログインしているときは上記を表示する %>
     <div class="card__wrapper">
-      <% @prototypes.each do |prototype| %>
-        <%= render partial: "prototype", locals: { prototype: prototype } %>
-      <% end %>
+      <%= render @prototypes %>
     </div>
   </div>
 </main>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -45,12 +45,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_09_092656) do
     t.text "concept", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_prototypes_on_user_id"
   end
 
-  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-
-ActiveRecord::Schema[7.0].define(version: 2024_05_09_084930) do
   create_table "users", charset: "utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -67,4 +65,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_09_084930) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
# what
プロトタイプ投稿機能のうち、ユーザー情報との外部キーによる紐付け
メイン画面における投稿の一覧表示

# why
前回のブランチではユーザー機能が存在していなかったため、あらためてユーザー情報が含まれた状態でブランチをきり、ユーザー情報との紐付けを行う必要があった。
メイン画面における一覧表示が、今後の詳細ページのリンク元となるため必要だった。